### PR TITLE
Add test for posts with nil users

### DIFF
--- a/spec/features/timeline_with_nil_users_spec.rb
+++ b/spec/features/timeline_with_nil_users_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+require 'support/features/clearance_helpers'
+
+# This can be removed if/when we decide not to have posts with nil users in
+# our production database
+RSpec.feature 'Timeline works with nil users', type: :feature do
+  scenario 'Timeline doesn\'t explode with nil users' do
+    post = Post.new(message: "Here is an anonymous post!")
+    post.save(validate: false)
+    expect do
+      sign_in
+      visit '/posts'
+    end.not_to raise_error
+  end
+end


### PR DESCRIPTION
We have posts with nil users in production, so we should add a test that things work in this scenario.

CC @adamjohnsnow @JayWebDevCom — I should have suggested you do this!

Will break #32 (but also make sure it doesn't break production 🙂)